### PR TITLE
Added keyarg `(update-bg-p t)` to `#'draw-image-glyphs`

### DIFF
--- a/ft2-fonts.lisp
+++ b/ft2-fonts.lisp
@@ -40,8 +40,9 @@
                               (font clx-ft2:font)
                               x y
                               sequence &rest keys 
-			      &key (start 0) end translate width size)
-  (declare (ignorable keys start end translate width size))
+			      &key (start 0) end translate width size
+                                (update-bg-p t))
+  (declare (ignorable keys start end translate width size update-bg-p))
   (apply 'clx-ft2:draw-glyphs
          drawable
          gcontext

--- a/ft2-fonts.lisp
+++ b/ft2-fonts.lisp
@@ -40,9 +40,8 @@
                               (font clx-ft2:font)
                               x y
                               sequence &rest keys 
-			      &key (start 0) end translate width size
-                                (update-bg-p t))
-  (declare (ignorable keys start end translate width size update-bg-p))
+			      &key (start 0) end translate width size)
+  (declare (ignorable keys start end translate width size))
   (apply 'clx-ft2:draw-glyphs
          drawable
          gcontext
@@ -50,4 +49,5 @@
   	 sequence
   	 :font font
 	 :allow-other-keys t
+         :update-bg-p t
 	 keys))


### PR DESCRIPTION
This commit adds the keyarg update-bg-p with a default value of t. This gets
passed to clx-ft2:draw-glyphs, and is required for the reversed fg/bg colors
that StumpWM uses for highlighting.

This fixes an issue where highlighted text (eg `^Rtext^r`) in StumpWM renders with foreground and background colors the same.